### PR TITLE
Fix README heading capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Navigate to the /srv directory on the container (where the root of this reposito
 cd /srv
 ```
 
-Server the Documents so that they are accessible from your Host Machine:
+Serve the documents so that they are accessible from your host machine:
 
 ```bash
 mkdocs serve -a 0.0.0.0:8000


### PR DESCRIPTION
## Summary
- correct capitalization in documentation

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6842a2295d8c832eba331eca09013848