### PR TITLE
Fix helm installation path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,7 +190,7 @@ RUN \
   # Install Helm
   curl -fsSL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
   chmod +x /tmp/get_helm.sh && \
-  ./tmp/get_helm.sh && \
+  /tmp/get_helm.sh && \
   \
   # Install ghorg
   wget -qO /tmp/ghorg.tar.gz https://github.com/gabrie30/ghorg/releases/download/v${GHORG_VERSION}/ghorg_${GHORG_VERSION}_Linux_${GHORG_ARCH_VALUE}.tar.gz && \


### PR DESCRIPTION
## Summary
- use `/tmp/get_helm.sh` for Helm install

## Testing
- `grep -n get_helm.sh -n Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_6842adf65614832e9f0850c3d9f087b9